### PR TITLE
Add ability to set camera heading

### DIFF
--- a/src/foundations/scenes/look_at/LookAt.zig
+++ b/src/foundations/scenes/look_at/LookAt.zig
@@ -29,6 +29,7 @@ pub fn init(allocator: std.mem.Allocator, cfg: *config) *LookAt {
         lkt,
         integrator,
         .{ 1, 3.5, 1 },
+        null,
     );
     errdefer cam.deinit(allocator);
     const grid = scenery.Grid.init(allocator);

--- a/src/foundations/scenes/plane_distance/PlaneDistance.zig
+++ b/src/foundations/scenes/plane_distance/PlaneDistance.zig
@@ -30,7 +30,8 @@ pub fn init(allocator: std.mem.Allocator, cfg: *config) *PlaneDistance {
         cfg,
         pd,
         integrator,
-        .{ 0, 0, 0 },
+        .{ 0, 200, -100 },
+        std.math.pi * 0.75,
     );
     errdefer cam.deinit(allocator);
     const grid = scenery.Grid.init(allocator);
@@ -88,7 +89,6 @@ pub fn updatePlane(self: *PlaneDistance, m: math.matrix) void {
     const n = math.vector.normalize(math.vector.crossProduct(u, v));
     const d: f32 = math.vector.dotProduct(math.vector.negate(n), q);
     self.plane = math.geometry.Plane.init(n, d);
-    self.plane.debug();
 }
 
 pub fn updatePlaneTransform(self: *PlaneDistance, prog: u32) void {

--- a/src/foundations/scenes/plane_distance/PlaneDistanceUI.zig
+++ b/src/foundations/scenes/plane_distance/PlaneDistanceUI.zig
@@ -4,7 +4,7 @@ rotation: [3]f32 = .{
     std.math.pi,
     std.math.pi,
 },
-translate: [3]f32 = .{ -100, 100, -100 },
+translate: [3]f32 = .{ -100, -100, -100 },
 updated: bool = true,
 
 const PlaneDistanceUI = @This();


### PR DESCRIPTION
Set it for plane distance scene so that it looks at the side the plane is pointing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The camera is now enabled by default upon initialization, enhancing user experience.
  - Users can specify a heading angle during camera setup, improving orientation control.
  - Added flexibility in the `LookAt` module's initialization with a new parameter.

- **Bug Fixes**
  - Adjusted the `PlaneDistance` initialization parameters for better rendering.
  - Removed debugging output in the `updatePlane` function to streamline performance.

- **Improvements**
  - UI translation has been optimized to center objects along the y-axis more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->